### PR TITLE
Cache dependencies locally to avoid rerunning preprocessor

### DIFF
--- a/src/models/Makefile.am
+++ b/src/models/Makefile.am
@@ -32,7 +32,7 @@ model_ranlib_LDADD = $(BASE_LDADD)
 model_strip_SOURCES = model-strip.cc $(COMMON_TOOLCHAIN_SOURCES)
 model_strip_LDADD = $(BASE_LDADD)
 
-model_ld_SOURCES = model-ld.cc model-linker-base.cc $(COMMON_TOOLCHAIN_SOURCES)
+model_ld_SOURCES = model-ld.cc model-linker-base.cc model-gcc-base.cc $(COMMON_TOOLCHAIN_SOURCES)
 model_ld_LDADD = $(BASE_LDADD)
 
 EXTRA_DIST = generate-toolchain-header.py

--- a/src/models/model-gcc-base.cc
+++ b/src/models/model-gcc-base.cc
@@ -128,3 +128,46 @@ string GCCModelGenerator::stage_output_name( const GCCStage stage, const string 
     throw runtime_error( "invalid GCCstage stage" );
   }
 }
+
+void error_if( const char * name )
+{
+  if ( getenv( name ) ) {
+    throw runtime_error( "unsupported environment variable: " + string( name ) );
+  }
+}
+
+string environment_or_blank( const string & name )
+{
+  const char * value = getenv( name.c_str() );
+  if ( value ) {
+    return name + "=" + value;
+  } else {
+    return name + "=";
+  }
+}
+
+void verify_no_unhandled_environment_variables()
+{
+  error_if( "CPATH" );
+  error_if( "C_INCLUDE_PATH" );
+  error_if( "CPLUS_INCLUDE_PATH" );
+  error_if( "OBJC_INCLUDE_PATH" );
+  error_if( "DEPENDENCIES_OUTPUT" );
+  error_if( "SUNPRO_DEPENDENCIES" );
+  error_if( "SOURCE_DATE_EPOCH" );
+  error_if( "GCC_EXEC_PREFIX" );
+  error_if( "COMPILER_PATH" );
+  error_if( "LIBRARY_PATH" );
+}
+
+vector<string> GCCModelGenerator::gcc_environment()
+{
+  verify_no_unhandled_environment_variables();
+
+  vector<string> environment;
+  environment.push_back( environment_or_blank( "LANG" ) );
+  environment.push_back( environment_or_blank( "LC_CTYPE" ) );
+  environment.push_back( environment_or_blank( "LC_MESSAGES" ) );
+  environment.push_back( environment_or_blank( "LC_ALL" ) );
+  return environment;
+}

--- a/src/models/model-gcc.cc
+++ b/src/models/model-gcc.cc
@@ -158,7 +158,6 @@ Thunk GCCModelGenerator::generate_thunk( const GCCStage first_stage,
 
     if ( generate_makedep_file ) {
       cerr << "\u251c\u2500 generating make dependencies file... ";
-      generate_dependencies_file( all_args, {} );
       makedep_filename = *arguments_.option_argument( GCCOption::MF );
       Optional<string> mt_arg = arguments_.option_argument( GCCOption::MT );
       if ( mt_arg.initialized() ) {
@@ -175,11 +174,11 @@ Thunk GCCModelGenerator::generate_thunk( const GCCStage first_stage,
       cerr << "done." << endl;
     }
     else {
-      generate_dependencies_file( all_args, makedep_tempfile.name() );
       makedep_filename = makedep_tempfile.name();
     }
 
-    vector<string> dependencies = parse_dependencies_file( makedep_filename, makedep_target );
+    const vector<string> dependencies = generate_dependencies_file( input.name, all_args,
+                                                                    makedep_filename, makedep_target );
 
     all_args.insert( all_args.begin(), "-specs=/__gg__/gcc-specs" );
     all_args.push_back( "-o" );

--- a/src/models/model-gcc.hh
+++ b/src/models/model-gcc.hh
@@ -160,8 +160,10 @@ private:
   std::vector<std::string> parse_dependencies_file( const std::string & dep_filename,
                                                     const std::string & target_name );
 
-  void generate_dependencies_file( const std::vector<std::string> & option_args,
-                                   const std::string & output_name );
+  std::vector<std::string> generate_dependencies_file( const std::string & input_filename,
+                                                       const std::vector<std::string> & option_args,
+                                                       const std::string & output_name,
+                                                       const std::string & target_name );
 
   gg::thunk::Thunk generate_thunk( const GCCStage first_stage,
                                    const GCCStage stage,

--- a/src/models/model-gcc.hh
+++ b/src/models/model-gcc.hh
@@ -174,6 +174,8 @@ private:
                                         const std::vector<std::string> & dependencies,
                                         const std::string & output );
 
+  static std::vector<std::string> gcc_environment();
+
 public:
   GCCModelGenerator( const OperationMode operation_mode, int argc, char ** argv );
   void generate();

--- a/src/models/model-linker-base.cc
+++ b/src/models/model-linker-base.cc
@@ -7,17 +7,58 @@
 #include <sstream>
 #include <regex>
 #include <iostream>
+#include <algorithm>
 
 #include "system_runner.hh"
+#include "digest.hh"
+#include "ggpaths.hh"
+#include "thunk_reader.hh"
 
 using namespace std;
 
 vector<string>
 GCCModelGenerator::parse_linker_output( const vector<string> & linker_args )
 {
-  unordered_set<string> dependencies;
+  /* do we have a valid cache for these dependencies? */
+  string command_line;
+  for ( const auto & str : linker_args ) {
+    command_line.append( str );
+    command_line.append( 1, '\0' );
+  }
 
-  istringstream output { run( linker_args.front(), linker_args, {}, true, true, true, true ) };
+  const auto cache_entry_path = gg::paths::dependency_cache_entry( digest::sha256( command_line ) );
+
+  /* assemble the function */
+  const gg::thunk::Function makedep_fn { linker_args.front(), linker_args, gcc_environment(), linker_args.front() };
+
+  if ( roost::exists( cache_entry_path ) ) {
+    /* abuse the thunk format to store a cache of dependencies */
+    ThunkReader thunk_reader( cache_entry_path.string() );
+    const gg::thunk::Thunk dep_cache_entry = thunk_reader.read_thunk();
+
+    /* do we have a possible cache hit? */
+    if ( makedep_fn == dep_cache_entry.function() ) {
+      bool cache_hit = true;
+
+      /* check if all the infiles are still the same */
+      for ( const auto & infile : dep_cache_entry.infiles() ) {
+        if ( not infile.matches_filesystem() ) {
+          cache_hit = false;
+          break;
+        }
+      }
+
+      if ( cache_hit ) {
+        vector<string> ret;
+        for ( const auto & str : dep_cache_entry.infiles() ) {
+          ret.emplace_back( str.filename() );
+        }
+        return ret;
+      }
+    }
+  }
+
+  istringstream linker_output { run( linker_args.front(), linker_args, {}, true, true, true, true ) };
 
   size_t seperator_line_count = 0;
 
@@ -26,7 +67,9 @@ GCCModelGenerator::parse_linker_output( const vector<string> & linker_args )
   smatch match;
   string line;
 
-  while ( getline( output, line ) ) {
+  unordered_set<string> dependencies;
+
+  while ( getline( linker_output, line ) ) {
     if ( seperator_line_count < 2 and line[ 0 ] == '=' ) {
       seperator_line_count++;
       continue;
@@ -42,5 +85,26 @@ GCCModelGenerator::parse_linker_output( const vector<string> & linker_args )
     }
   }
 
-  return { dependencies.begin(), dependencies.end() };
+  const vector<string> the_dependencies { dependencies.begin(), dependencies.end() };
+
+  /* write a cache entry for next time */
+
+    /* assemble the infiles */
+  vector<gg::thunk::InFile> infiles_vec;
+  for ( const auto & str : the_dependencies ) {
+    infiles_vec.emplace_back( str );
+  }
+
+  gg::thunk::Thunk dep_cache_entry( "",
+                                    makedep_fn,
+                                    infiles_vec );
+
+  /* serialize and write the fake thunk */
+  string serialized_cache_entry { gg::thunk::MAGIC_NUMBER };
+  if ( not dep_cache_entry.to_protobuf().AppendToString( &serialized_cache_entry ) ) {
+    throw runtime_error( "could not serialize cache entry" );
+  }
+  atomic_create( serialized_cache_entry, cache_entry_path );
+
+  return the_dependencies;
 }

--- a/src/models/model-preprocessor.cc
+++ b/src/models/model-preprocessor.cc
@@ -147,7 +147,7 @@ vector<string> GCCModelGenerator::generate_dependencies_file( const string & inp
 
   /* do we have a valid cache for these dependencies? */
   const string input_file_hash = gg::thunk::InFile::compute_hash( input_filename );
-  const auto cache_entry_path = gg::paths::preprocessor_dependency_cache_entry( input_file_hash );
+  const auto cache_entry_path = gg::paths::dependency_cache_entry( input_file_hash );
 
   /* assemble the function */
   const gg::thunk::Function makedep_fn { args.front(), args, gcc_environment(), args.front() };
@@ -178,10 +178,6 @@ vector<string> GCCModelGenerator::generate_dependencies_file( const string & inp
   run( args[ 0 ], args, {}, true, true );
 
   /* write a cache entry for next time */
-  FileDescriptor outfile { CheckSystemCall( "open (" + output_name + ")",
-                                            open( output_name.c_str(), O_RDONLY ) ) };
-  string contents;
-  while ( not outfile.eof() ) { contents += outfile.read(); }
 
   /* assemble the infiles */
   const vector<string> infiles_list = parse_dependencies_file( output_name, target_name );

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -21,7 +21,7 @@ AM_TESTS_ENVIRONMENT = \
 
 check_PROGRAMS = thunk-roundtrip sandbox-test path-test
 dist_check_SCRIPTS = fetch-vectors.test \
-                     model-preprocess.test model-preprocess-makedep.test \
+                     model-preprocess.test \
                      model-compile.test model-assemble.test model-link.test \
                      model-ar.test model-ranlib.test model-strip.test \
                      model-ld.test gnu-hello.test mosh.test \
@@ -34,7 +34,6 @@ path_test_SOURCES = path-test.cc
 TESTS = $(check_PROGRAMS) $(dist_check_SCRIPTS)
 
 model-preprocess.log: fetch-vectors.log
-model-preprocess-makedep.log: fetch-vectors.log
 model-compile.log: fetch-vectors.log
 model-assemble.log: fetch-vectors.log
 model-link.log: fetch-vectors.log
@@ -45,7 +44,7 @@ model-ld.log: fetch-vectors.log
 gnu-hello.log: fetch-vectors.log
 mosh.log: fetch-vectors.log
 
-cleanup.log: model-preprocess.log model-preprocess-makedep.log \
+cleanup.log: model-preprocess.log \
              model-compile.log model-assemble.log model-link.log model-ar.log \
              model-ranlib.log model-strip.log model-ld.log gnu-hello.log \
              mosh.log

--- a/src/thunk/ggpaths.cc
+++ b/src/thunk/ggpaths.cc
@@ -80,6 +80,12 @@ namespace gg {
       return hash_cache_path;
     }
 
+    roost::path preprocessor_dependency_cache()
+    {
+      const static roost::path cache_path = get_inner_directory( "depcache" );
+      return cache_path;
+    }
+
     roost::path blob_path( const string & hash )
     {
       return blobs() / hash;
@@ -95,6 +101,11 @@ namespace gg {
       const string cache_key = to_string( stat_entry.st_dev ) + "-"
         + to_string( stat_entry.st_ino ) + "-" + roost::rbasename( filename ).string();
       return hash_cache() / cache_key;
+    }
+
+    roost::path preprocessor_dependency_cache_entry( const string & input_hash )
+    {
+      return preprocessor_dependency_cache() / input_hash;
     }
 
     void fix_path_envar()

--- a/src/thunk/ggpaths.cc
+++ b/src/thunk/ggpaths.cc
@@ -80,7 +80,7 @@ namespace gg {
       return hash_cache_path;
     }
 
-    roost::path preprocessor_dependency_cache()
+    roost::path dependency_cache()
     {
       const static roost::path cache_path = get_inner_directory( "depcache" );
       return cache_path;
@@ -103,9 +103,9 @@ namespace gg {
       return hash_cache() / cache_key;
     }
 
-    roost::path preprocessor_dependency_cache_entry( const string & input_hash )
+    roost::path dependency_cache_entry( const string & cache_key )
     {
-      return preprocessor_dependency_cache() / input_hash;
+      return dependency_cache() / cache_key;
     }
 
     void fix_path_envar()

--- a/src/thunk/ggpaths.hh
+++ b/src/thunk/ggpaths.hh
@@ -17,12 +17,12 @@ namespace gg {
     roost::path reductions();
     roost::path remote_index();
     roost::path hash_cache();
-    roost::path preprocessor_dependency_cache();
+    roost::path dependency_cache();
 
     roost::path blob_path( const std::string & hash );
     roost::path reduction_path( const std::string & hash );
     roost::path hash_cache_entry( const std::string & filename, const struct stat & stat_entry );
-    roost::path preprocessor_dependency_cache_entry( const std::string & input_hash );
+    roost::path dependency_cache_entry( const std::string & cache_key );
 
     void fix_path_envar();
   }

--- a/src/thunk/ggpaths.hh
+++ b/src/thunk/ggpaths.hh
@@ -17,10 +17,12 @@ namespace gg {
     roost::path reductions();
     roost::path remote_index();
     roost::path hash_cache();
+    roost::path preprocessor_dependency_cache();
 
     roost::path blob_path( const std::string & hash );
     roost::path reduction_path( const std::string & hash );
     roost::path hash_cache_entry( const std::string & filename, const struct stat & stat_entry );
+    roost::path preprocessor_dependency_cache_entry( const std::string & input_hash );
 
     void fix_path_envar();
   }

--- a/src/thunk/infile.cc
+++ b/src/thunk/infile.cc
@@ -103,6 +103,23 @@ size_t InFile::compute_order( const string & filename )
   }
 }
 
+/* does the same file exist, with same contents, in the filesystem? */
+bool InFile::matches_filesystem() const
+{
+  /* does it exist at all? */
+  if ( not roost::exists( real_filename_ ) ) {
+    return false;
+  }
+
+  /* does it have the same size? */
+  if ( size() != compute_size( real_filename_ ) ) {
+    return false;
+  }
+
+  /* does it have the same contents? */
+  return ( content_hash() == compute_hash( real_filename_ ) );
+}
+
 string InFile::compute_hash( const string & filename )
 {
   /* do we have this hash in cache? */

--- a/src/thunk/thunk.hh
+++ b/src/thunk/thunk.hh
@@ -68,6 +68,9 @@ namespace gg {
       static size_t compute_order( const std::string & filename );
       static std::string compute_hash( const std::string & filename );
       static off_t compute_size( const std::string & filename );
+
+      /* does the same file exist, with same contents, in the filesystem? */
+      bool matches_filesystem() const;
     };
 
     class Function


### PR DESCRIPTION
This abuses the thunk format to store a local cache of dependencies in the "depcache" subdir.

The logic being, if the hash of the input file is the same, and the hash of **all** of the infiles on disk is still the same, then there's no need to rerun `gcc -M`.