### PR TITLE
Add missing boto3 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To build `gg` you need the following packages:
 - `libtool`
 - `pkg-config`
 - `libhiredis-dev`
+- `python3-boto3`
 
 You can install this dependencies in Ubuntu (17.04 or newer) by running:
 
@@ -39,7 +40,7 @@ You can install this dependencies in Ubuntu (17.04 or newer) by running:
 sudo apt-get install gcc-7 g++-7 protobuf-compiler libprotobuf-dev \
                      libcrypto++-dev libcap-dev \
                      libncurses5-dev libboost-dev libssl-dev autopoint help2man \
-                     libhiredis-dev texinfo automake libtool pkg-config
+                     libhiredis-dev texinfo automake libtool pkg-config python3-boto3
 ```
 
 To build `gg`, run the following commands:


### PR DESCRIPTION
`boto3` should be installed either through apt or through pip. This is needed for `make ggfunctions`.