### PR TITLE
Computation-Based Graph

### DIFF
--- a/src/execution/reductor.hh
+++ b/src/execution/reductor.hh
@@ -26,16 +26,18 @@ private:
     Clock::time_point start {};
     std::chrono::milliseconds timeout { 0 };
     uint8_t restarts { std::numeric_limits<uint8_t>::max() };
+    ComputationId id{0};
   };
 
   const std::vector<std::string> target_hashes_;
-  std::unordered_set<std::string> remaining_targets_;
+  std::vector<std::string> remaining_targets_;
   bool status_bar_;
 
   ExecutionGraph dep_graph_ {};
 
-  std::deque<std::string> job_queue_ {};
+  std::deque<std::pair<ComputationId, std::string>> job_queue_ {};
   std::unordered_map<std::string, JobInfo> running_jobs_ {};
+  std::unordered_multimap<std::string, ComputationId> ids_ {};
   size_t finished_jobs_ { 0 };
   float estimated_cost_ { 0.0 };
 
@@ -50,7 +52,8 @@ private:
 
   std::unique_ptr<StorageBackend> storage_backend_;
 
-  void finalize_execution( const std::string & old_hash,
+  void finalize_execution( const ComputationId id,
+                           const std::string & old_hash,
                            std::vector<gg::ThunkOutput> && outputs,
                            const float cost = 0.0 );
 

--- a/src/execution/reductor.hh
+++ b/src/execution/reductor.hh
@@ -26,7 +26,6 @@ private:
     Clock::time_point start {};
     std::chrono::milliseconds timeout { 0 };
     uint8_t restarts { std::numeric_limits<uint8_t>::max() };
-    ComputationId id{0};
   };
 
   const std::vector<std::string> target_hashes_;
@@ -35,9 +34,8 @@ private:
 
   ExecutionGraph dep_graph_ {};
 
-  std::deque<std::pair<ComputationId, std::string>> job_queue_ {};
+  std::deque<std::string> job_queue_ {};
   std::unordered_map<std::string, JobInfo> running_jobs_ {};
-  std::unordered_multimap<std::string, ComputationId> ids_ {};
   size_t finished_jobs_ { 0 };
   float estimated_cost_ { 0.0 };
 
@@ -52,8 +50,7 @@ private:
 
   std::unique_ptr<StorageBackend> storage_backend_;
 
-  void finalize_execution( const ComputationId id,
-                           const std::string & old_hash,
+  void finalize_execution( const std::string & old_hash,
                            std::vector<gg::ThunkOutput> && outputs,
                            const float cost = 0.0 );
 

--- a/src/thunk/graph.hh
+++ b/src/thunk/graph.hh
@@ -1,4 +1,5 @@
 /* -*-mode:c++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 sw=2 tw=80 : */
 
 #ifndef GRAPH_HH
 #define GRAPH_HH
@@ -14,44 +15,101 @@
 #include "thunk/thunk.hh"
 #include "util/optional.hh"
 
+typedef std::string Hash;
+
+// A computation denotes a node in the graph which is in the process of being reduced.
+// If (+ 3 4) was reduced to 7, then both would have the same ComputationId,
+// just at different points in time.
+typedef size_t ComputationId;
+struct Computation {
+  // Whether the `thunk` field accurately reflects the current state
+  bool up_to_date {false};
+  // The executable (but potentially out-of-date) thunk
+  gg::thunk::Thunk thunk;
+
+  // The outputs for this computation. Empty if a thunk. Non-empty if a value.
+  std::vector<gg::ThunkOutput> outputs {};
+
+  // Computations that this one depends on.
+  std::unordered_set<ComputationId> deps {};
+  // Computations dependent on this one.
+  std::unordered_set<ComputationId> rev_deps {};
+  // The hashes that this thunk knows its dependencies by
+  std::unordered_map<ComputationId, Hash> dep_hashes {};
+
+  Computation( gg::thunk::Thunk && thunk );
+
+  bool is_value() const { return not outputs.empty(); }
+};
+
 class ExecutionGraph
 {
 private:
-  std::unordered_map<std::string, gg::thunk::Thunk> thunks_ {};
+  // Computations, maybe irreducible, maybe not
+  std::unordered_map<ComputationId, Computation> computations_ {};
 
-  std::unordered_map<std::string, std::unordered_set<std::string>> referencing_thunks_ {};
+  // Number of computations that must be reduced
+  size_t n_unreduced {0};
 
-  std::unordered_set<std::string> value_dependencies_ {};
-  std::unordered_set<std::string> executable_dependencies_ {};
+  // The ComputationId for known hashes
+  std::unordered_map<Hash, ComputationId> ids_ {};
 
-  std::unordered_map<std::string, std::string> original_hashes_ {};
-  std::unordered_map<std::string, std::string> updated_hashes_ {};
+  // The hashes of pre-existing blobs (values or executables) that this
+  // function depends on.
+  std::unordered_set<Hash> blob_dependencies_ {};
 
-  void update_hash( const std::string & old_hash,
-                    const std::vector<gg::ThunkOutput> & outputs );
+  ComputationId next_id_ {0};
+
+  // Place the thunk at the indicated location, and pull in dependencies
+  void _emplace_thunk( ComputationId id,
+                       gg::thunk::Thunk && thunk );
+
+  // Given a computation `id`, ensures that said `id` either:
+  //    * refers to a value OR
+  //    * refers to an up-to-date computation (one with a thunk that reflects
+  //    the current comptution)
+  void _update( const ComputationId id );
+
+  // Given a computation `id`, marks this `id` (and all transitive dependents)
+  // as out-of-date.
+  void _mark_out_of_date( const ComputationId id );
+
+  // Record that `from` depends on `on`. `on_hash` is the **parent's** name for
+  // the child.
+  void _create_dependency( const ComputationId from,
+                           const Hash & on_hash,
+                           const ComputationId on );
+
+  // Cut the dependencies from `computation`
+  void _cut_dependencies( const ComputationId id );
+
+  // Get a list of executable thunks
+  std::set<std::pair<ComputationId, Hash>>
+  order_one_dependencies( const ComputationId id ) const;
 
 public:
-  std::string add_thunk( const std::string & hash );
 
-  Optional<std::unordered_set<std::string>>
-  force_thunk( const std::string & old_hash,
-               std::vector<gg::ThunkOutput> && outputs );
+  // Adds a computation for this thunk to the graph. A No-op if present.
+  // If `trace` is set, then this thunk will be queryable
+  ComputationId add_thunk( const Hash & hash );
 
-  const std::unordered_set<std::string> &
-  value_dependencies() const { return value_dependencies_; }
+  // Given a `hash`, determines the value of that hash, if it is known.
+  Optional<Hash> query_value( const Hash & hash ) const;
 
-  const std::unordered_set<std::string> &
-  executable_dependencies() const { return executable_dependencies_; }
+  // Informs that graph that `from` reduces to `to`.
+  // Returns newly executable thunks.
+  std::set<std::pair<ComputationId, Hash>>
+  submit_reduction( const ComputationId id, const Hash & from, std::vector<gg::ThunkOutput> && to );
 
-  std::unordered_set<std::string>
-  order_one_dependencies( const std::string & hash ) const;
+  // Get a list of executable thunks
+  std::set<std::pair<ComputationId, Hash>>
+  order_one_dependencies( const Hash & hash ) const;
 
-  const gg::thunk::Thunk &
-  get_thunk( const std::string & hash ) const { return thunks_.at( hash ); }
+  // Get initial blobs that the computation is dependent on
+  const std::unordered_set<Hash> &
+  blob_dependencies() const { return blob_dependencies_; }
 
-  std::string updated_hash( const std::string & original_hash ) const;
-  std::string original_hash( const std::string & updated_hash ) const;
-  size_t size() const { return thunks_.size(); }
+  size_t size() const { return n_unreduced; }
 };
 
 #endif /* GRAPH_HH */


### PR DESCRIPTION
This PR introduces a new structure for `ExecutionGraph`.

Originally the `ExecutionGraph` contained thunk nodes which were keyed by their hash, and dependencies were also expressed as hashes. This meant that when a reduction was applied, all ancestral node would technically have their hashes change, and their keys change, and thus would require a change to all references to them. An example:

```
   A
  / \
 B   C
  \ /
   D
```

Say that `D` becomes `D'`, with a new hash. Then `B` and `C` must also be updated, as must `A`.

This sort of pervasive global response to every local modification is, of course, unreasonable, and not necessary to solve the problem.

To avoid global updates, the old implementation had a lazy update strategy which assumed  bottom-up execution of the graph.

@sadjad and I have been planning to add support for non-bottom-up execution strategies, e.g. to support such behaviors as "short-circuiting" thunks, which return whenever any one of their dependencies does. Note that these kinds of strategies break the assumptions of the original graph implementation's update policy, and are in general harder to write correct lazy update strategies for.

Thus, we've designed this new `ExecutionGraph` to allow for a more general lazy update strategy, ultimately facilitating interesting kinds of control flow.

In this graph, when thunks are inserted they are assigned a `ComputationId` that *will never change*. As the node is reduced, new thunks that it reduces to will be assigned that same `ComputationId`, and ultimately the irreducible value of the thunk will be assigned that ID as well. Thus, `ComputationId`s serve as stable names for computations that *do not change* during the reduction process. By expressing dependencies as `ComputationId`s, dependencies become more stable during the update process. In particular, this (mostly) separates the process of hash updating from the process of graph structure change. This make writing a correct lazy hash-update system much easier.

A final note: sometimes two computations converge and end up with the same cache. In this case we implement what is essentially an optimization by linking one to the other. 

Major credits to @sadjad for doing this with me.