### PR TITLE
Trim crypto++

### DIFF
--- a/src/models/gcc.cc
+++ b/src/models/gcc.cc
@@ -29,7 +29,6 @@
 #include "util/optional.hh"
 #include "util/system_runner.hh"
 #include "util/temp_file.hh"
-#include "util/tokenize.hh"
 #include "util/timeit.hh"
 #include "util/util.hh"
 #include "util/ipc_socket.hh"

--- a/src/models/generate-deps.cc
+++ b/src/models/generate-deps.cc
@@ -1,7 +1,8 @@
 /* -*-mode:c++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 
-#include <iostream>
 #include <algorithm>
+#include <fstream>
+#include <iostream>
 
 #include "gcc.hh"
 #include "timeouts.hh"

--- a/src/models/generic.cc
+++ b/src/models/generic.cc
@@ -1,6 +1,8 @@
 /* -*-mode:c++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 
+#include <fstream>
 #include <getopt.h>
+#include <iostream>
 
 #include "timeouts.hh"
 #include "cli_description.hh"

--- a/src/thunk/factory.cc
+++ b/src/thunk/factory.cc
@@ -16,7 +16,6 @@
 #include "util/file_descriptor.hh"
 #include "util/optional.hh"
 #include "util/path.hh"
-#include "util/tokenize.hh"
 
 using namespace std;
 using namespace std::chrono;

--- a/src/thunk/ggutils.cc
+++ b/src/thunk/ggutils.cc
@@ -8,20 +8,18 @@
 #include <sys/fcntl.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <crypto++/sha.h>
-#include <crypto++/hex.h>
-#include <crypto++/base64.h>
 
 #include "thunk_reader.hh"
+#include "util/base64.hh"
 #include "util/digest.hh"
 #include "util/exception.hh"
 #include "util/file_descriptor.hh"
+#include "util/hex.hh"
 #include "util/tokenize.hh"
 #include "util/util.hh"
 #include "util/xdg.hh"
 
 using namespace std;
-using namespace CryptoPP;
 
 namespace gg {
 
@@ -290,7 +288,7 @@ namespace gg {
 
       replace( ret.begin(), ret.end(), '-', '.' );
       output_sstr << to_underlying( type ) << ret << setfill( '0' )
-                  << setw( 8 ) << hex << input.length();
+                  << setw( 8 ) << std::hex << input.length();
       return output_sstr.str();
     }
 
@@ -351,16 +349,11 @@ namespace gg {
 
     string to_hex( const string & gghash )
     {
-      string output;
-
       string hash = gghash.substr( 1, gghash.length() - 9 );
       replace( hash.begin(), hash.end(), '.', '-' );
       hash += '=';
 
-      StringSource s( hash, true,
-                      new Base64URLDecoder(
-                      new HexEncoder(
-                      new StringSink( output ), false ) ) );
+      const string output = hex::encode( base64::decode( hash ) );
 
       if ( output.length() == 64 ) {
         return output;

--- a/src/thunk/thunk.cc
+++ b/src/thunk/thunk.cc
@@ -9,13 +9,13 @@
 #include <algorithm>
 #include <numeric>
 #include <regex>
-#include <crypto++/base64.h>
 
 #include "protobufs/util.hh"
 #include "thunk/ggutils.hh"
 #include "thunk/factory.hh"
 #include "thunk/placeholder.hh"
 #include "thunk/thunk_writer.hh"
+#include "util/base64.hh"
 #include "util/digest.hh"
 #include "util/system_runner.hh"
 #include "util/temp_file.hh"
@@ -23,7 +23,6 @@
 using namespace std;
 using namespace gg;
 using namespace gg::thunk;
-using namespace CryptoPP;
 
 string thunk::data_placeholder( const string & hash )
 {
@@ -228,9 +227,7 @@ protobuf::RequestItem Thunk::execution_request( const Thunk & thunk )
 {
   protobuf::RequestItem request_item;
 
-  string base64_thunk;
-  StringSource s( ThunkWriter::serialize( thunk ), true,
-                  new Base64Encoder( new StringSink( base64_thunk ), false ) );
+  string base64_thunk = base64::encode( ThunkWriter::serialize( thunk ) );
 
   request_item.set_data( base64_thunk );
   request_item.set_hash( thunk.hash() );

--- a/src/thunk/thunk.cc
+++ b/src/thunk/thunk.cc
@@ -10,7 +10,6 @@
 #include <numeric>
 #include <regex>
 #include <crypto++/base64.h>
-#include <crypto++/files.h>
 
 #include "protobufs/util.hh"
 #include "thunk/ggutils.hh"

--- a/src/thunk/thunk.cc
+++ b/src/thunk/thunk.cc
@@ -9,6 +9,8 @@
 #include <algorithm>
 #include <numeric>
 #include <regex>
+#include <crypto++/base64.h>
+#include <crypto++/files.h>
 
 #include "protobufs/util.hh"
 #include "thunk/ggutils.hh"

--- a/src/thunk/thunk.hh
+++ b/src/thunk/thunk.hh
@@ -12,8 +12,6 @@
 #include <regex>
 #include <chrono>
 #include <sys/types.h>
-#include <crypto++/base64.h>
-#include <crypto++/files.h>
 
 #include "protobufs/thunk.pb.h"
 #include "protobufs/gg.pb.h"

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -9,6 +9,7 @@ libggutil_a_SOURCES = exception.hh optional.hh chunk.hh \
                       child_process.hh child_process.cc \
                       digest.hh digest.cc \
                       base64.hh base64.cc \
+                      hex.hh hex.cc \
                       system_runner.hh system_runner.cc \
                       temp_file.hh temp_file.cc \
                       temp_dir.hh temp_dir.cc \

--- a/src/util/base64.cc
+++ b/src/util/base64.cc
@@ -2,8 +2,6 @@
 
 #include "base64.hh"
 
-#include <crypto++/sha.h>
-#include <crypto++/hex.h>
 #include <crypto++/base64.h>
 
 using namespace CryptoPP;
@@ -11,7 +9,6 @@ using namespace std;
 
 string base64::encode( const string & input )
 {
-  SHA256 hash_function;
   string ret;
 
   /* Each stage of the Crypto++ pipeline will delete the pointer it owns
@@ -25,7 +22,6 @@ string base64::encode( const string & input )
 
 string base64::decode( const string & input )
 {
-  SHA256 hash_function;
   string ret;
 
   /* Each stage of the Crypto++ pipeline will delete the pointer it owns

--- a/src/util/digest.cc
+++ b/src/util/digest.cc
@@ -3,7 +3,6 @@
 #include "digest.hh"
 
 #include <crypto++/sha.h>
-#include <crypto++/hex.h>
 #include <crypto++/base64.h>
 
 using namespace CryptoPP;

--- a/src/util/hex.cc
+++ b/src/util/hex.cc
@@ -1,0 +1,19 @@
+#include "hex.hh"
+
+#include <crypto++/hex.h>
+
+using namespace CryptoPP;
+using namespace std;
+
+string hex::encode( const string & input )
+{
+  string ret;
+
+  /* Each stage of the Crypto++ pipeline will delete the pointer it owns
+     (https://www.cryptopp.com/wiki/Pipelining) */
+
+  StringSource s( input, true,
+                  new HexEncoder( new StringSink( ret ) ) );
+
+  return ret;
+}

--- a/src/util/hex.hh
+++ b/src/util/hex.hh
@@ -1,0 +1,12 @@
+#ifndef HEX_HH
+#define HEX_HH
+
+#include <string>
+
+namespace hex
+{
+  std::string encode( const std::string & input );
+}
+
+#endif /* HEX_HH */
+


### PR DESCRIPTION
Isolate our dependencies on `crypto++`.

First of all, this should (slightly) improve compile times.

Second, since the location of the `crypto++` headers is platform-dependent, this includes will need to be macro-guarded, or something like that, so it makes sense to thin them out.