### PR TITLE
Scripts for vendoring deps

### DIFF
--- a/contrib/get-cryptopp.sh
+++ b/contrib/get-cryptopp.sh
@@ -1,0 +1,6 @@
+set -e
+cd third_party
+git clone --depth 1 -b CRYPTOPP_8_2_0 https://github.com/weidai11/cryptopp.git
+cd cryptopp
+make libcryptopp.a -j $(nproc)
+make install -j $(nproc) PREFIX=../install

--- a/contrib/get-hiredis.sh
+++ b/contrib/get-hiredis.sh
@@ -1,0 +1,5 @@
+cd third_party
+git clone --depth 1 -b v1.0.0 https://github.com/redis/hiredis.git
+cd hiredis
+git apply ../../contrib/hiredis-not-shared.patch
+

--- a/contrib/get-openssl.sh
+++ b/contrib/get-openssl.sh
@@ -1,0 +1,7 @@
+set -e
+cd third_party
+git clone --depth 1 -b OpenSSL_1_1_1g https://github.com/openssl/openssl.git
+cd openssl
+./config --prefix=$(pwd)/../install
+make -j $(nproc)
+make install -j $(nproc)

--- a/contrib/get-protobuf.sh
+++ b/contrib/get-protobuf.sh
@@ -1,0 +1,15 @@
+set -xe
+cd third_party
+version=3.12.0
+if [[ -a protobuf-${version} ]]; then
+    echo "Protobuf already there"
+else
+    wget https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protobuf-cpp-${version}.tar.gz
+    tar xvf protobuf-cpp-${version}.tar.gz
+    rm protobuf-cpp-${version}.tar.gz
+    cd protobuf-${version}
+    ./autogen.sh
+    ./configure --prefix=$(pwd)/../install
+    make -j$(nproc)
+    make install
+fi

--- a/contrib/hiredis-not-shared.patch
+++ b/contrib/hiredis-not-shared.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1beccc6..e073075 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -40,7 +40,7 @@ IF(WIN32)
+     ADD_COMPILE_DEFINITIONS(_CRT_SECURE_NO_WARNINGS WIN32_LEAN_AND_MEAN)
+ ENDIF()
+ 
+-ADD_LIBRARY(hiredis SHARED ${hiredis_sources})
++ADD_LIBRARY(hiredis ${hiredis_sources})
+ 
+ SET_TARGET_PROPERTIES(hiredis
+     PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE

--- a/fetch-deps.sh
+++ b/fetch-deps.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -ex
+[[ -a third_party/openssl ]] || ./contrib/get-openssl.sh
+[[ -a third_party/cryptopp ]] || ./contrib/get-cryptopp.sh
+[[ -a third_party/hiredis ]] || ./contrib/get-hiredis.sh
+[[ -a third_party/protobuf-3.12.0 ]] || ./contrib/get-protobuf.sh

--- a/third_party/.gitignore
+++ b/third_party/.gitignore
@@ -1,0 +1,5 @@
+install
+protobuf*
+openssl*
+cryptopp*
+hiredis*


### PR DESCRIPTION
As discussed, scripts for fetching/building dependencies.

Doesn't build hiredis, b/c it uses CMake, so one can just add it as a subdirectory.